### PR TITLE
Adding Support for Cucumber version greater than v0.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ You can configure multiple formats, with each format configured to output to the
 $ node_modules/.bin/parallel-cucumber-js -f json:./output.json -f progress
 ```
 
+### parallel-cucumber-js v1.0.0 supports Cucumber version greater than 0.7.0
+
+### parallel-cucumber-js v0.1.7 supports Cucumber version 0.7.0 and lesser
+
 ### Example
 
 See https://github.com/simondean/parallel-cucumber-js-example for an example

--- a/README.md
+++ b/README.md
@@ -105,9 +105,9 @@ You can configure multiple formats, with each format configured to output to the
 $ node_modules/.bin/parallel-cucumber-js -f json:./output.json -f progress
 ```
 
-### parallel-cucumber-js v1.0.0 supports Cucumber version greater than 0.7.0
+### parallel-cucumber-js v1.x.x supports Cucumber version greater than 0.7.0
 
-### parallel-cucumber-js v0.1.7 supports Cucumber version 0.7.0 and lesser
+### parallel-cucumber-js v0.x.x supports Cucumber version 0.7.0 and lesser
 
 ### Example
 

--- a/lib/parallel_cucumber/cli/configuration.js
+++ b/lib/parallel_cucumber/cli/configuration.js
@@ -69,8 +69,6 @@ var Configuration = function(argv) {
   self.tags = ensureValueIsAnArray(args['tags']);
   self.profiles = args['profiles'];
   self.cucumberPath = args['cucumber'];
-  console.log('args::', args);
-  console.log('cucuberPAth::', self.cucumberPath);
   self.maxRetries = args['max-retries'];
   self.dryRun = args['dry-run'];
   self.debug = args['debug'];

--- a/lib/parallel_cucumber/cli/configuration.js
+++ b/lib/parallel_cucumber/cli/configuration.js
@@ -69,6 +69,8 @@ var Configuration = function(argv) {
   self.tags = ensureValueIsAnArray(args['tags']);
   self.profiles = args['profiles'];
   self.cucumberPath = args['cucumber'];
+  console.log('args::', args);
+  console.log('cucuberPAth::', self.cucumberPath);
   self.maxRetries = args['max-retries'];
   self.dryRun = args['dry-run'];
   self.debug = args['debug'];

--- a/lib/parallel_cucumber/runtime.js
+++ b/lib/parallel_cucumber/runtime.js
@@ -162,35 +162,35 @@ var Runtime = function(configuration) {
   self._createFormatters = function(options, callback) {
     self.formatters = [];
 
-    //self._configuration.formats.forEach(function(format) {
-    //  console.log('format =====: ', format);
-    //  var parts = format.split(':');
-    //  var formatterName = parts[0];
-    //  var outFilePath = parts.slice(1).join(':');
-    //  var formatterType;
-    //
-    //  if (formatterName.toLowerCase() === 'json') {
-    //    formatterType = ParallelCucumber.Formatters.JsonFormatter;
-    //  }
-    //  else if (formatterName.toLowerCase() === 'progress') {
-    //    formatterType = ParallelCucumber.Formatters.ProgressFormatter;
-    //  }
-    //  else {
-    //    try {
-    //      formatterType = require(Path.resolve(formatterName));
-    //    }
-    //    catch (err) {
-    //      callback({ message: 'Failed to load custom formatter', formatter: formatterName, innerError: err });
-    //      return;
-    //    }
-    //  }
-    //
-    //  var formatter = formatterType({ outFilePath: outFilePath });
-    //  //self.formatters.push(formatter);
-    //
-    //  self.formatters.push(format);
-    //});
+    self._configuration.formats.forEach(function(format) {
+      console.log('format =====: ', format);
+      var parts = format.split(':');
+      var formatterName = parts[0];
+      var outFilePath = parts.slice(1).join(':');
+      var formatterType;
 
+      if (formatterName.toLowerCase() === 'json') {
+        formatterType = ParallelCucumber.Formatters.JsonFormatter;
+      }
+      else if (formatterName.toLowerCase() === 'progress') {
+        formatterType = ParallelCucumber.Formatters.ProgressFormatter;
+      }
+      else {
+        try {
+          formatterType = require(Path.resolve(formatterName));
+        }
+        catch (err) {
+          callback({ message: 'Failed to load custom formatter', formatter: formatterName, innerError: err });
+          return;
+        }
+      }
+
+      var formatter = formatterType({ outFilePath: outFilePath });
+      self.formatters.push(formatter);
+
+      //self.formatters.push(format);
+    });
+    //
     callback();
   };
 

--- a/lib/parallel_cucumber/runtime.js
+++ b/lib/parallel_cucumber/runtime.js
@@ -38,7 +38,7 @@ var Runtime = function(configuration) {
           options.featureFilePaths = results[0];
           options.supportCodePaths = results[1];
 
-          Debug('Feature file paths YEEEEE:', options.featureFilePaths);
+          Debug('Feature file paths:', options.featureFilePaths);
           Debug('Support code paths:', options.supportCodePaths);
 
           self._executeFeaturesOnWorkerPool(
@@ -163,7 +163,6 @@ var Runtime = function(configuration) {
     self.formatters = [];
 
     self._configuration.formats.forEach(function(format) {
-      console.log('format =====: ', format);
       var parts = format.split(':');
       var formatterName = parts[0];
       var outFilePath = parts.slice(1).join(':');
@@ -187,10 +186,8 @@ var Runtime = function(configuration) {
 
       var formatter = formatterType({ outFilePath: outFilePath });
       self.formatters.push(formatter);
-
-      //self.formatters.push(format);
     });
-    //
+
     callback();
   };
 
@@ -217,7 +214,6 @@ var Runtime = function(configuration) {
           env: env,
           retryCount: 0
         };
-        Debug('task for each YEE: ', task);
         tasks.push(task);
       });
     });

--- a/lib/parallel_cucumber/runtime.js
+++ b/lib/parallel_cucumber/runtime.js
@@ -217,7 +217,7 @@ var Runtime = function(configuration) {
         tasks.push(task);
       });
     });
-    Debug('tasks YEE: ', tasks);
+    Debug('tasks: ', tasks);
     callback(null, tasks);
   };
 

--- a/lib/parallel_cucumber/runtime.js
+++ b/lib/parallel_cucumber/runtime.js
@@ -2,7 +2,7 @@ var Runtime = function(configuration) {
   var ParallelCucumber = require('../parallel_cucumber');
   var Async = require('async');
   var Path = require('path');
-  var Debug = require('debug')('parallel-cucumber-js');
+  var Debug = require('debug')('parallel-cucumber-js:runtime');
 
   var self = {};
 
@@ -38,7 +38,7 @@ var Runtime = function(configuration) {
           options.featureFilePaths = results[0];
           options.supportCodePaths = results[1];
 
-          Debug('Feature file paths:', options.featureFilePaths);
+          Debug('Feature file paths YEEEEE:', options.featureFilePaths);
           Debug('Support code paths:', options.supportCodePaths);
 
           self._executeFeaturesOnWorkerPool(
@@ -162,31 +162,34 @@ var Runtime = function(configuration) {
   self._createFormatters = function(options, callback) {
     self.formatters = [];
 
-    self._configuration.formats.forEach(function(format) {
-      var parts = format.split(':');
-      var formatterName = parts[0];
-      var outFilePath = parts.slice(1).join(':');
-      var formatterType;
-
-      if (formatterName.toLowerCase() === 'json') {
-        formatterType = ParallelCucumber.Formatters.JsonFormatter;
-      }
-      else if (formatterName.toLowerCase() === 'progress') {
-        formatterType = ParallelCucumber.Formatters.ProgressFormatter;
-      }
-      else {
-        try {
-          formatterType = require(Path.resolve(formatterName));
-        }
-        catch (err) {
-          callback({ message: 'Failed to load custom formatter', formatter: formatterName, innerError: err });
-          return;
-        }
-      }
-
-      var formatter = formatterType({ outFilePath: outFilePath });
-      self.formatters.push(formatter);
-    });
+    //self._configuration.formats.forEach(function(format) {
+    //  console.log('format =====: ', format);
+    //  var parts = format.split(':');
+    //  var formatterName = parts[0];
+    //  var outFilePath = parts.slice(1).join(':');
+    //  var formatterType;
+    //
+    //  if (formatterName.toLowerCase() === 'json') {
+    //    formatterType = ParallelCucumber.Formatters.JsonFormatter;
+    //  }
+    //  else if (formatterName.toLowerCase() === 'progress') {
+    //    formatterType = ParallelCucumber.Formatters.ProgressFormatter;
+    //  }
+    //  else {
+    //    try {
+    //      formatterType = require(Path.resolve(formatterName));
+    //    }
+    //    catch (err) {
+    //      callback({ message: 'Failed to load custom formatter', formatter: formatterName, innerError: err });
+    //      return;
+    //    }
+    //  }
+    //
+    //  var formatter = formatterType({ outFilePath: outFilePath });
+    //  //self.formatters.push(formatter);
+    //
+    //  self.formatters.push(format);
+    //});
 
     callback();
   };
@@ -214,11 +217,11 @@ var Runtime = function(configuration) {
           env: env,
           retryCount: 0
         };
-
+        Debug('task for each YEE: ', task);
         tasks.push(task);
       });
     });
-
+    Debug('tasks YEE: ', tasks);
     callback(null, tasks);
   };
 

--- a/lib/parallel_cucumber/runtime/worker_pool.js
+++ b/lib/parallel_cucumber/runtime/worker_pool.js
@@ -3,7 +3,7 @@ var WorkerPool = function(options) {
   var Events = require('events');
   var ChildProcess = require('child_process');
   var Async = require('async');
-  var Debug = require('debug')('parallel-cucumber-js');
+  var Debug = require('debug')('parallel-cucumber-js:worker_pool');
 
   var self = new Events.EventEmitter();
 
@@ -68,7 +68,7 @@ var WorkerPool = function(options) {
             self.workers[workerIndex] = worker;
 
             worker.on('message', function(message) {
-              Debug('Received message');
+              Debug('Received message: ', message);
               if (message.cmd === 'start') {
                 worker.send({ cmd: 'init', workerIndex: workerIndex, cucumberPath: self.options.cucumberPath, dryRun: self.options.dryRun });
                 worker.send({ cmd: 'task', task: task });
@@ -80,6 +80,10 @@ var WorkerPool = function(options) {
               else if (message.cmd === 'next') {
                 Debug('Received "next" message');
                 nextTask(message.workerIndex);
+              }
+              else if (message.cmd === 'error') {
+                Debug('Child error:', message);
+                self.emit('error', message);
               }
             });
 

--- a/lib/parallel_cucumber_worker/cli/main.js
+++ b/lib/parallel_cucumber_worker/cli/main.js
@@ -1,6 +1,6 @@
 var Main = function() {
   var Path = require('path');
-  var Debug = require('debug')('parallel-cucumber-js');
+  var Debug = require('debug')('parallel-cucumber-js:parallel_cucumber_worker:main:::');
 
   var self = {};
 
@@ -8,6 +8,7 @@ var Main = function() {
 
   process.on('message', function(message) {
     if (message.cmd === 'init') {
+      Debug('Worker ' + self.workerIndex + ' received "init" message');
       self._init(message);
       Debug('Worker ' + self.workerIndex + ' received "init" message');
     }
@@ -36,69 +37,74 @@ var Main = function() {
       cucumberPath = Path.resolve(cucumberPath);
     }
 
+    Debug('cucumberPath: ', options.cucumberPath);
+
     self.Cucumber = require(cucumberPath);
-    var RealAstTreeWalker = self.Cucumber.Runtime.AstTreeWalker;
+    //var RealAstTreeWalker = self.Cucumber.Runtime.AstTreeWalker;
+    //
+    //var optionsss = { dryRun: undefined, failFast: undefined, strict: undefined };
 
-    self.Cucumber.Runtime.AstTreeWalker = function(features, supportCodeLibrary, listeners) {
-      var self2 = RealAstTreeWalker(features, supportCodeLibrary, listeners);
+  //  self.Cucumber.Runtime.AstTreeWalker = function(features, supportCodeLibrary, listeners, optionsss) {
+  //    var self2 = RealAstTreeWalker(features, supportCodeLibrary, listeners, optionsss);
+  //
+  //    var emptyCollection = self.Cucumber.Type.Collection();
+  //    var realBroadcastEvent = self2.broadcastEvent;
+  //    var realGetListeners = supportCodeLibrary.getListeners;
+  //
+  //
+  //    function disableSupportCodeListeners() {
+  //      supportCodeLibrary.getListeners = function() {
+  //        return emptyCollection;
+  //      };
+  //    }
+  //
+  //    function enableSupportCodeListeners() {
+  //      supportCodeLibrary.getListeners = realGetListeners;
+  //    }
+  //
+  //    function isCensoredEvent(event) {
+  //      var name = event.getName();
+  //
+  //      if (name === 'BeforeFeatures') {
+  //        if (self.beforeFeatures) {
+  //          self.beforeFeatures = false;
+  //          return false;
+  //        }
+  //
+  //        return true;
+  //      }
+  //      else if (name === 'AfterFeatures') {
+  //        return true;
+  //      }
+  //      else {
+  //        return false;
+  //      }
+  //    }
+  //    self2.broadcastEvent = function(event, callback) {
+  //      if (isCensoredEvent(event)) {
+  //        disableSupportCodeListeners();
+  //        realBroadcastEvent(event, function() {
+  //          enableSupportCodeListeners();
+  //          callback();
+  //        });
+  //      }
+  //      else {
+  //        realBroadcastEvent(event, callback);
+  //      }
+  //    };
+  //
+  //    self2.broadcastEventUncensored = function(event, callback) {
+  //      realBroadcastEvent(event, callback);
+  //    };
+  //
+  //    self.astTreeWalker = self2;
+  //    return self2;
+  //  };
+  //
+  //  Object.keys(RealAstTreeWalker).forEach(function(key) {
+  //    self.Cucumber.Runtime.AstTreeWalker[key] = RealAstTreeWalker[key];
+  //  });
 
-      var emptyCollection = self.Cucumber.Type.Collection();
-      var realBroadcastEvent = self2.broadcastEvent;
-      var realGetListeners = supportCodeLibrary.getListeners;
-
-      self2.broadcastEvent = function(event, callback) {
-        if (isCensoredEvent(event)) {
-          disableSupportCodeListeners();
-          realBroadcastEvent(event, function() {
-            enableSupportCodeListeners();
-            callback();
-          });
-        }
-        else {
-          realBroadcastEvent(event, callback);
-        }
-      };
-
-      self2.broadcastEventUncensored = function(event, callback) {
-        realBroadcastEvent(event, callback);
-      };
-
-      function disableSupportCodeListeners() {
-        supportCodeLibrary.getListeners = function() {
-          return emptyCollection;
-        };
-      }
-
-      function enableSupportCodeListeners() {
-        supportCodeLibrary.getListeners = realGetListeners;
-      }
-
-      function isCensoredEvent(event) {
-        var name = event.getName();
-
-        if (name === 'BeforeFeatures') {
-          if (self.beforeFeatures) {
-            self.beforeFeatures = false;
-            return false;
-          }
-
-          return true;
-        }
-        else if (name === 'AfterFeatures') {
-          return true;
-        }
-        else {
-          return false;
-        }
-      }
-
-      self.astTreeWalker = self2;
-      return self2;
-    };
-
-    Object.keys(RealAstTreeWalker).forEach(function(key) {
-      self.Cucumber.Runtime.AstTreeWalker[key] = RealAstTreeWalker[key];
-    });
   };
 
   self._task = function(options) {
@@ -108,6 +114,11 @@ var Main = function() {
 
     // Cucumber ignores the first two arguments
     var argv = ['', ''];
+    argv.push('-f');
+    argv.push('json:tests/acceptance/report/cucumber_report_en_US.html.json');
+
+    argv.push('-f');
+    argv.push('json');
 
     self.task.supportCodePaths.forEach(function(supportCodePath) {
       argv.push('-r');
@@ -131,54 +142,96 @@ var Main = function() {
       process.env[envName] = self.task.env[envName];
     });
 
-    var configuration = self.Cucumber.Cli.Configuration(argv);
-    var runtime = self.Cucumber.Runtime(configuration);
-    var formatter = self.Cucumber.Listener.JsonFormatter(
-      {
-        logToConsole: false,
-        logToFunction: self._writeReport
-      }
-    );
-    runtime.attachListener(formatter);
-    runtime.start(function(success) {
-      Object.keys(originalEnv).forEach(function(envName) {
-        if (typeof originalEnv[envName] === 'undefined') {
-          delete process.env[envName];
-        }
-        else {
-          process.env[envName] = originalEnv[envName];
-        }
-      });
+    //var configuration = self.Cucumber.Cli.Configuration(argv);
 
-      self._taskDone(success);
+    //var configuration = self.Cucumber.Cli.Configuration({ version: '0.9.4',
+    //  backtrace: undefined,
+    //  compiler: [],
+    //  dryRun: undefined,
+    //  failFast: undefined,
+    //  format: [ 'pretty', 'json' ],
+    //  name: [],
+    //  colors: true,
+    //  snippets: true,
+    //  source: true,
+    //  profile: [],
+    //  require:
+    //      [ 'tests/acceptance/step_definitions/',
+    //        'tests/acceptance/step_definitions/' ],
+    //  snippetSyntax: undefined,
+    //  strict: undefined,
+    //  tags: [ '~@blocked', '~@todo', '@email' ] },
+    //    [ 'tests/acceptance/features/' ]);
+    //
+    //var runtime = self.Cucumber.Runtime(configuration);
+    //var formatter = self.Cucumber.Listener.JsonFormatter(
+    //  {
+    //    logToConsole: false,
+    //    logToFunction: self._writeReport
+    //  }
+    //);
+    //runtime.attachListener(formatter);
+    //runtime.start(function(success) {
+    //  Object.keys(originalEnv).forEach(function(envName) {
+    //    if (typeof originalEnv[envName] === 'undefined') {
+    //      delete process.env[envName];
+    //    }
+    //    else {
+    //      process.env[envName] = originalEnv[envName];
+    //    }
+    //  });
+    //
+    //  self._taskDone(success);
+    //});
+
+    console.log('argv === ', argv);
+
+    var cli = self.Cucumber.Cli(argv);
+
+    cli.run(function (succeeded) {
+        Object.keys(originalEnv).forEach(function(envName) {
+          if (typeof originalEnv[envName] === 'undefined') {
+            delete process.env[envName];
+          }
+          else {
+            process.env[envName] = originalEnv[envName];
+          }
+        });
+
+      Debug('Task Done YEE: ', succeeded);
+
+        self._taskDone(succeeded);
     });
+
   };
 
   self._writeReport = function (value) {
-    Debug(self);
+    Debug('self:::', self);
     self.output.push(value);
   };
 
   self._taskDone = function(success) {
     Debug('Success:', success);
 
-    var report = self.output.join('');
-
-    try {
-      report = JSON.parse(report);
-    }
-    catch (e) {
-      if (!(e instanceof SyntaxError)) {
-        throw e;
-      }
-
-      process.send({ cmd: 'error', workerIndex: self.workerIndex, profileName: self.task.profileName, message: 'Syntax error in the JSON report: ' + e });
-      Debug('Sent "report" message');
-      return;
-    }
-
-    process.send({ cmd: 'report', workerIndex: self.workerIndex, task: self.task, report: report, success: success });
-    Debug('Sent "report" message');
+    //var report = self.output.join('');
+    //
+    //console.log('report:::::=== ', report);
+    //
+    //try {
+    //  report = JSON.parse(report);
+    //}
+    //catch (e) {
+    //  if (!(e instanceof SyntaxError)) {
+    //    throw e;
+    //  }
+    //
+    //  process.send({ cmd: 'error', workerIndex: self.workerIndex, profileName: self.task.profileName, message: 'Syntax error in the JSON report: ' + e });
+    //  Debug('Sent "error" message');
+    //  return;
+    //}
+    //
+    //process.send({ cmd: 'report', workerIndex: self.workerIndex, task: self.task, report: report, success: success });
+    //Debug('Sent "report" message');
     process.send({ cmd: 'next', workerIndex: self.workerIndex });
     Debug('Sent "next" message');
   };
@@ -189,16 +242,16 @@ var Main = function() {
       process.exit(0);
     }
 
-    if (self.astTreeWalker) {
-      var event = self.Cucumber.Runtime.AstTreeWalker.Event('AfterFeatures');
-
-      self.astTreeWalker.broadcastEventUncensored(event, function() {
-        exit();
-      });
-    }
-    else {
+    //if (self.astTreeWalker) {
+    //  var event = self.Cucumber.Runtime.AstTreeWalker.Event('AfterFeatures');
+    //
+    //  self.astTreeWalker.broadcastEventUncensored(event, function() {
+    //    exit();
+    //  });
+    //}
+    //else {
       exit();
-    }
+    //}
   };
 
   self._pathIsAModule = function(path) {

--- a/lib/parallel_cucumber_worker/cli/main.js
+++ b/lib/parallel_cucumber_worker/cli/main.js
@@ -1,312 +1,199 @@
 var Main = function() {
-  var Path = require('path');
-  var Command = require('commander').Command;
-  var Debug = require('debug')('parallel-cucumber-js:parallel_cucumber_worker:main:::');
+    var Path = require('path');
+    var Command = require('commander').Command;
+    var Debug = require('debug')('parallel-cucumber-js:parallel_cucumber_worker:main:::');
 
-  var self = {};
+    var self = {};
 
-  Debug('Process current working directory:', process.cwd());
+    Debug('Process current working directory:', process.cwd());
 
-  process.on('message', function(message) {
-    if (message.cmd === 'init') {
-      Debug('Worker ' + self.workerIndex + ' received "init" message');
-      self._init(message);
-      Debug('Worker ' + self.workerIndex + ' received "init" message');
-    }
-    else if (message.cmd === 'task') {
-      Debug('Worker ' + self.workerIndex + ' received "task" message');
-      self._task(message);
-    }
-    else if (message.cmd === 'exit') {
-      Debug('Worker ' + self.workerIndex + ' received "exit" message');
-      self._exit();
-    }
-  });
-
-  self.start = function() {
-    process.send({ cmd: 'start' });
-  };
-
-  self._init = function(options) {
-    self.workerIndex = options.workerIndex;
-    self.dryRun = options.dryRun;
-    self.beforeFeatures = true;
-
-    var cucumberPath = options.cucumberPath;
-
-    if (!self._pathIsAModule(cucumberPath)) {
-      cucumberPath = Path.resolve(cucumberPath);
-    }
-
-    Debug('cucumberPath: ', options.cucumberPath);
-
-    self.Cucumber = require(cucumberPath);
-    //var RealAstTreeWalker = self.Cucumber.Runtime.AstTreeWalker;
-    //
-    //var optionsss = { dryRun: undefined, failFast: undefined, strict: undefined };
-
-  //  self.Cucumber.Runtime.AstTreeWalker = function(features, supportCodeLibrary, listeners, optionsss) {
-  //    var self2 = RealAstTreeWalker(features, supportCodeLibrary, listeners, optionsss);
-  //
-  //    var emptyCollection = self.Cucumber.Type.Collection();
-  //    var realBroadcastEvent = self2.broadcastEvent;
-  //    var realGetListeners = supportCodeLibrary.getListeners;
-  //
-  //
-  //    function disableSupportCodeListeners() {
-  //      supportCodeLibrary.getListeners = function() {
-  //        return emptyCollection;
-  //      };
-  //    }
-  //
-  //    function enableSupportCodeListeners() {
-  //      supportCodeLibrary.getListeners = realGetListeners;
-  //    }
-  //
-  //    function isCensoredEvent(event) {
-  //      var name = event.getName();
-  //
-  //      if (name === 'BeforeFeatures') {
-  //        if (self.beforeFeatures) {
-  //          self.beforeFeatures = false;
-  //          return false;
-  //        }
-  //
-  //        return true;
-  //      }
-  //      else if (name === 'AfterFeatures') {
-  //        return true;
-  //      }
-  //      else {
-  //        return false;
-  //      }
-  //    }
-  //    self2.broadcastEvent = function(event, callback) {
-  //      if (isCensoredEvent(event)) {
-  //        disableSupportCodeListeners();
-  //        realBroadcastEvent(event, function() {
-  //          enableSupportCodeListeners();
-  //          callback();
-  //        });
-  //      }
-  //      else {
-  //        realBroadcastEvent(event, callback);
-  //      }
-  //    };
-  //
-  //    self2.broadcastEventUncensored = function(event, callback) {
-  //      realBroadcastEvent(event, callback);
-  //    };
-  //
-  //    self.astTreeWalker = self2;
-  //    return self2;
-  //  };
-  //
-  //  Object.keys(RealAstTreeWalker).forEach(function(key) {
-  //    self.Cucumber.Runtime.AstTreeWalker[key] = RealAstTreeWalker[key];
-  //  });
-
-  };
-
-  self._task = function(options) {
-    self.task = options.task;
-    self.output = [];
-    Debug('Task:', self.task);
-
-    // Cucumber ignores the first two arguments
-    var argv = ['', ''];
-    //argv.push('-f');
-    //argv.push('json:tests/acceptance/report/cucumber_report_en_US.html.json');
-    //
-    //argv.push('-f');
-    //argv.push('json');
-
-    self.task.supportCodePaths.forEach(function(supportCodePath) {
-      argv.push('-r');
-      argv.push(supportCodePath);
-    });
-    self.task.tags.forEach(function(tagExpression) {
-      argv.push('-t');
-      argv.push(tagExpression);
-    });
-    argv.push(self.task.featureFilePath);
-    Debug('Cucumber argv:', argv);
-
-    Debug('Setting the PARALLEL_CUCUMBER_PROFILE environment variable to \'' + self.task.profileName + '\'');
-    process.env.PARALLEL_CUCUMBER_PROFILE = self.task.profileName;
-    process.env.PARALLEL_CUCUMBER_DRY_RUN = self.dryRun;
-    process.env.PARALLEL_CUCUMBER_RETRY = self.task.retryCount.toString();
-    var originalEnv = {};
-
-    Object.keys(self.task.env).forEach(function(envName) {
-      originalEnv[envName] = process.env[envName];
-      process.env[envName] = self.task.env[envName];
-    });
-
-
-    function collect(val, memo) {
-      memo.push(val);
-      return memo;
-    }
-
-    function getProgram () {
-      var program = new Command(Path.basename(argv[1]));
-
-      program
-          .usage('[options] [<DIR|FILE[:LINE]>...]')
-          .version(self.Cucumber.VERSION, '-v, --version')
-          .option('-b, --backtrace', 'show full backtrace for errors')
-          .option('--compiler <EXTENSION:MODULE>', 'require files with the given EXTENSION after requiring MODULE (repeatable)', collect, [])
-          .option('-d, --dry-run', 'invoke formatters without executing steps')
-          .option('--fail-fast', 'abort the run on first failure')
-          .option('-f, --format <TYPE[:PATH]>', 'specify the output format, optionally supply PATH to redirect formatter output (repeatable)', collect, ['pretty'])
-          .option('--name <REGEXP>', 'only execute the scenarios with name matching the expression (repeatable)', collect, [])
-          .option('--no-colors', 'disable colors in formatter output')
-          .option('--no-snippets', 'hide step definition snippets for pending steps')
-          .option('--no-source', 'hide source uris')
-          .option('-p, --profile <NAME>', 'specify the profile to use (repeatable)', collect, [])
-          .option('-r, --require <FILE|DIR>', 'require files before executing features (repeatable)', collect, [])
-          .option('--snippet-syntax <FILE>', 'specify a custom snippet syntax')
-          .option('-S, --strict', 'fail if there are any undefined or pending steps')
-          .option('-t, --tags <EXPRESSION>', 'only execute the features or scenarios with tags matching the expression (repeatable)', collect, []);
-
-      program.on('--help', function(){
-        console.log('  For more details please visit https://github.com/cucumber/cucumber-js#cli\n');
-      });
-
-      return program;
-    }
-
-    function getConfiguration() {
-      var program = getProgram();
-      program.parse(argv);
-      var profileArgs = self.Cucumber.Cli.ProfilesLoader.getArgs(program.profile);
-      if (profileArgs.length > 0) {
-        var fullArgs = argv.slice(0, 2).concat(profileArgs).concat(argv.slice(2));
-        program = getProgram();
-        program.parse(fullArgs);
-      }
-      var configuration = self.Cucumber.Cli.Configuration(program.opts(), program.args);
-      return configuration;
-    }
-
-    var configuration = getConfiguration();
-
-    //var configuration = self.Cucumber.Cli.Configuration({ version: '0.9.4',
-    //  backtrace: undefined,
-    //  compiler: [],
-    //  dryRun: undefined,
-    //  failFast: undefined,
-    //  format: [ 'pretty', 'json' ],
-    //  name: [],
-    //  colors: true,
-    //  snippets: true,
-    //  source: true,
-    //  profile: [],
-    //  require:
-    //      [ 'tests/acceptance/step_definitions/',
-    //        'tests/acceptance/step_definitions/' ],
-    //  snippetSyntax: undefined,
-    //  strict: undefined,
-    //  tags: [ '~@blocked', '~@todo', '@email' ] },
-    //    [ 'tests/acceptance/features/' ]);
-    //
-    var runtime = self.Cucumber.Runtime(configuration);
-    var formatter = self.Cucumber.Listener.JsonFormatter(
-      {
-        logToConsole: false,
-        logToFunction: self._writeReport
-      }
-    );
-    runtime.attachListener(formatter);
-    runtime.start(function(success) {
-      Object.keys(originalEnv).forEach(function(envName) {
-        if (typeof originalEnv[envName] === 'undefined') {
-          delete process.env[envName];
+    process.on('message', function(message) {
+        if (message.cmd === 'init') {
+            Debug('Worker ' + self.workerIndex + ' received "init" message');
+            self._init(message);
+            Debug('Worker ' + self.workerIndex + ' received "init" message');
         }
-        else {
-          process.env[envName] = originalEnv[envName];
+        else if (message.cmd === 'task') {
+            Debug('Worker ' + self.workerIndex + ' received "task" message');
+            self._task(message);
         }
-      });
-
-      self._taskDone(success);
+        else if (message.cmd === 'exit') {
+            Debug('Worker ' + self.workerIndex + ' received "exit" message');
+            self._exit();
+        }
     });
 
-    //console.log('argv === ', argv);
-    //
-    //var cli = self.Cucumber.Cli(argv);
-    //
-    //cli.run(function (succeeded) {
-    //    Object.keys(originalEnv).forEach(function(envName) {
-    //      if (typeof originalEnv[envName] === 'undefined') {
-    //        delete process.env[envName];
-    //      }
-    //      else {
-    //        process.env[envName] = originalEnv[envName];
-    //      }
-    //    });
-    //
-    //  Debug('Task Done YEE: ', succeeded);
-    //
-    //    self._taskDone(succeeded);
-    //});
+    self.start = function() {
+        process.send({cmd: 'start'});
+    };
 
-  };
+    self._init = function(options) {
+        self.workerIndex = options.workerIndex;
+        self.dryRun = options.dryRun;
+        self.beforeFeatures = true;
 
-  self._writeReport = function (value) {
-    Debug('self:::', self);
-    self.output.push(value);
-  };
+        var cucumberPath = options.cucumberPath;
 
-  self._taskDone = function(success) {
-    Debug('Success:', success);
+        if (!self._pathIsAModule(cucumberPath)) {
+            cucumberPath = Path.resolve(cucumberPath);
+        }
 
-    var report = self.output.join('');
+        Debug('cucumberPath: ', options.cucumberPath);
 
-    console.log('report:::::=== ', report);
+        self.Cucumber = require(cucumberPath);
 
-    try {
-      report = JSON.parse(report);
-    }
-    catch (e) {
-      if (!(e instanceof SyntaxError)) {
-        throw e;
-      }
+    };
 
-      process.send({ cmd: 'error', workerIndex: self.workerIndex, profileName: self.task.profileName, message: 'Syntax error in the JSON report: ' + e });
-      Debug('Sent "error" message');
-      return;
-    }
+    self._task = function(options) {
+        self.task = options.task;
+        self.output = [];
+        Debug('Task:', self.task);
 
-    process.send({ cmd: 'report', workerIndex: self.workerIndex, task: self.task, report: report, success: success });
-    Debug('Sent "report" message');
-    process.send({ cmd: 'next', workerIndex: self.workerIndex });
-    Debug('Sent "next" message');
-  };
+        // Cucumber ignores the first two arguments
+        var argv = ['', ''];
 
-  self._exit = function() {
-    function exit() {
-      process.disconnect();
-      process.exit(0);
-    }
+        self.task.supportCodePaths.forEach(function(supportCodePath) {
+            argv.push('-r');
+            argv.push(supportCodePath);
+        });
+        self.task.tags.forEach(function(tagExpression) {
+            argv.push('-t');
+            argv.push(tagExpression);
+        });
+        argv.push(self.task.featureFilePath);
 
-    //if (self.astTreeWalker) {
-    //  var event = self.Cucumber.Runtime.AstTreeWalker.Event('AfterFeatures');
-    //
-    //  self.astTreeWalker.broadcastEventUncensored(event, function() {
-    //    exit();
-    //  });
-    //}
-    //else {
-      exit();
-    //}
-  };
+        Debug('Cucumber argv:', argv);
+        Debug('Setting the PARALLEL_CUCUMBER_PROFILE environment variable to \'' + self.task.profileName + '\'');
 
-  self._pathIsAModule = function(path) {
-    return path === Path.basename(path);
-  };
+        process.env.PARALLEL_CUCUMBER_PROFILE = self.task.profileName;
+        process.env.PARALLEL_CUCUMBER_DRY_RUN = self.dryRun;
+        process.env.PARALLEL_CUCUMBER_RETRY = self.task.retryCount.toString();
+        var originalEnv = {};
 
-  return self;
+        Object.keys(self.task.env).forEach(function(envName) {
+            originalEnv[envName] = process.env[envName];
+            process.env[envName] = self.task.env[envName];
+        });
+
+
+        function collect(val, memo) {
+            memo.push(val);
+            return memo;
+        }
+
+        function getProgram() {
+            var program = new Command(Path.basename(argv[1]));
+
+            program
+                .usage('[options] [<DIR|FILE[:LINE]>...]')
+                .version(self.Cucumber.VERSION, '-v, --version')
+                .option('-b, --backtrace', 'show full backtrace for errors')
+                .option('--compiler <EXTENSION:MODULE>', 'require files with the given EXTENSION after requiring MODULE (repeatable)', collect, [])
+                .option('-d, --dry-run', 'invoke formatters without executing steps')
+                .option('--fail-fast', 'abort the run on first failure')
+                .option('-f, --format <TYPE[:PATH]>', 'specify the output format, optionally supply PATH to redirect formatter output (repeatable)', collect, ['pretty'])
+                .option('--name <REGEXP>', 'only execute the scenarios with name matching the expression (repeatable)', collect, [])
+                .option('--no-colors', 'disable colors in formatter output')
+                .option('--no-snippets', 'hide step definition snippets for pending steps')
+                .option('--no-source', 'hide source uris')
+                .option('-p, --profile <NAME>', 'specify the profile to use (repeatable)', collect, [])
+                .option('-r, --require <FILE|DIR>', 'require files before executing features (repeatable)', collect, [])
+                .option('--snippet-syntax <FILE>', 'specify a custom snippet syntax')
+                .option('-S, --strict', 'fail if there are any undefined or pending steps')
+                .option('-t, --tags <EXPRESSION>', 'only execute the features or scenarios with tags matching the expression (repeatable)', collect, []);
+
+            program.on('--help', function() {
+                console.log('  For more details please visit https://github.com/cucumber/cucumber-js#cli\n');
+            });
+
+            return program;
+        }
+
+        function getConfiguration() {
+            var program = getProgram();
+            program.parse(argv);
+            var profileArgs = self.Cucumber.Cli.ProfilesLoader.getArgs(program.profile);
+            if (profileArgs.length > 0) {
+                var fullArgs = argv.slice(0, 2).concat(profileArgs).concat(argv.slice(2));
+                program = getProgram();
+                program.parse(fullArgs);
+            }
+            return self.Cucumber.Cli.Configuration(program.opts(), program.args);
+        }
+
+        var configuration = getConfiguration();
+        var runtime = self.Cucumber.Runtime(configuration);
+        var formatter = self.Cucumber.Listener.JsonFormatter(
+            {
+                logToConsole: false,
+                logToFunction: self._writeReport
+            }
+        );
+
+        runtime.attachListener(formatter);
+
+        runtime.start(function(success) {
+            Object.keys(originalEnv).forEach(function(envName) {
+                if (typeof originalEnv[envName] === 'undefined') {
+                    delete process.env[envName];
+                }
+                else {
+                    process.env[envName] = originalEnv[envName];
+                }
+            });
+
+            self._taskDone(success);
+        });
+    };
+
+    self._writeReport = function(value) {
+        Debug('self:::', self);
+        self.output.push(value);
+    };
+
+    self._taskDone = function(success) {
+        Debug('Success:', success);
+
+        var report = self.output.join('');
+
+        try {
+            report = JSON.parse(report);
+        }
+        catch (e) {
+            if (!(e instanceof SyntaxError)) {
+                throw e;
+            }
+
+            process.send({
+                cmd: 'error',
+                workerIndex: self.workerIndex,
+                profileName: self.task.profileName,
+                message: 'Syntax error in the JSON report: ' + e
+            });
+            Debug('Sent "error" message');
+            return;
+        }
+
+        process.send({cmd: 'report', workerIndex: self.workerIndex, task: self.task, report: report, success: success});
+        Debug('Sent "report" message');
+        process.send({cmd: 'next', workerIndex: self.workerIndex});
+        Debug('Sent "next" message');
+    };
+
+    self._exit = function() {
+        function exit() {
+            process.disconnect();
+            process.exit(0);
+        }
+
+        exit();
+    };
+
+    self._pathIsAModule = function(path) {
+        return path === Path.basename(path);
+    };
+
+    return self;
 };
 
 module.exports = Main;

--- a/lib/parallel_cucumber_worker/cli/main.js
+++ b/lib/parallel_cucumber_worker/cli/main.js
@@ -1,5 +1,6 @@
 var Main = function() {
   var Path = require('path');
+  var Command = require('commander').Command;
   var Debug = require('debug')('parallel-cucumber-js:parallel_cucumber_worker:main:::');
 
   var self = {};
@@ -114,11 +115,11 @@ var Main = function() {
 
     // Cucumber ignores the first two arguments
     var argv = ['', ''];
-    argv.push('-f');
-    argv.push('json:tests/acceptance/report/cucumber_report_en_US.html.json');
-
-    argv.push('-f');
-    argv.push('json');
+    //argv.push('-f');
+    //argv.push('json:tests/acceptance/report/cucumber_report_en_US.html.json');
+    //
+    //argv.push('-f');
+    //argv.push('json');
 
     self.task.supportCodePaths.forEach(function(supportCodePath) {
       argv.push('-r');
@@ -142,7 +143,54 @@ var Main = function() {
       process.env[envName] = self.task.env[envName];
     });
 
-    //var configuration = self.Cucumber.Cli.Configuration(argv);
+
+    function collect(val, memo) {
+      memo.push(val);
+      return memo;
+    }
+
+    function getProgram () {
+      var program = new Command(Path.basename(argv[1]));
+
+      program
+          .usage('[options] [<DIR|FILE[:LINE]>...]')
+          .version(self.Cucumber.VERSION, '-v, --version')
+          .option('-b, --backtrace', 'show full backtrace for errors')
+          .option('--compiler <EXTENSION:MODULE>', 'require files with the given EXTENSION after requiring MODULE (repeatable)', collect, [])
+          .option('-d, --dry-run', 'invoke formatters without executing steps')
+          .option('--fail-fast', 'abort the run on first failure')
+          .option('-f, --format <TYPE[:PATH]>', 'specify the output format, optionally supply PATH to redirect formatter output (repeatable)', collect, ['pretty'])
+          .option('--name <REGEXP>', 'only execute the scenarios with name matching the expression (repeatable)', collect, [])
+          .option('--no-colors', 'disable colors in formatter output')
+          .option('--no-snippets', 'hide step definition snippets for pending steps')
+          .option('--no-source', 'hide source uris')
+          .option('-p, --profile <NAME>', 'specify the profile to use (repeatable)', collect, [])
+          .option('-r, --require <FILE|DIR>', 'require files before executing features (repeatable)', collect, [])
+          .option('--snippet-syntax <FILE>', 'specify a custom snippet syntax')
+          .option('-S, --strict', 'fail if there are any undefined or pending steps')
+          .option('-t, --tags <EXPRESSION>', 'only execute the features or scenarios with tags matching the expression (repeatable)', collect, []);
+
+      program.on('--help', function(){
+        console.log('  For more details please visit https://github.com/cucumber/cucumber-js#cli\n');
+      });
+
+      return program;
+    }
+
+    function getConfiguration() {
+      var program = getProgram();
+      program.parse(argv);
+      var profileArgs = self.Cucumber.Cli.ProfilesLoader.getArgs(program.profile);
+      if (profileArgs.length > 0) {
+        var fullArgs = argv.slice(0, 2).concat(profileArgs).concat(argv.slice(2));
+        program = getProgram();
+        program.parse(fullArgs);
+      }
+      var configuration = self.Cucumber.Cli.Configuration(program.opts(), program.args);
+      return configuration;
+    }
+
+    var configuration = getConfiguration();
 
     //var configuration = self.Cucumber.Cli.Configuration({ version: '0.9.4',
     //  backtrace: undefined,
@@ -163,45 +211,45 @@ var Main = function() {
     //  tags: [ '~@blocked', '~@todo', '@email' ] },
     //    [ 'tests/acceptance/features/' ]);
     //
-    //var runtime = self.Cucumber.Runtime(configuration);
-    //var formatter = self.Cucumber.Listener.JsonFormatter(
-    //  {
-    //    logToConsole: false,
-    //    logToFunction: self._writeReport
-    //  }
-    //);
-    //runtime.attachListener(formatter);
-    //runtime.start(function(success) {
-    //  Object.keys(originalEnv).forEach(function(envName) {
-    //    if (typeof originalEnv[envName] === 'undefined') {
-    //      delete process.env[envName];
-    //    }
-    //    else {
-    //      process.env[envName] = originalEnv[envName];
-    //    }
-    //  });
-    //
-    //  self._taskDone(success);
-    //});
+    var runtime = self.Cucumber.Runtime(configuration);
+    var formatter = self.Cucumber.Listener.JsonFormatter(
+      {
+        logToConsole: false,
+        logToFunction: self._writeReport
+      }
+    );
+    runtime.attachListener(formatter);
+    runtime.start(function(success) {
+      Object.keys(originalEnv).forEach(function(envName) {
+        if (typeof originalEnv[envName] === 'undefined') {
+          delete process.env[envName];
+        }
+        else {
+          process.env[envName] = originalEnv[envName];
+        }
+      });
 
-    console.log('argv === ', argv);
-
-    var cli = self.Cucumber.Cli(argv);
-
-    cli.run(function (succeeded) {
-        Object.keys(originalEnv).forEach(function(envName) {
-          if (typeof originalEnv[envName] === 'undefined') {
-            delete process.env[envName];
-          }
-          else {
-            process.env[envName] = originalEnv[envName];
-          }
-        });
-
-      Debug('Task Done YEE: ', succeeded);
-
-        self._taskDone(succeeded);
+      self._taskDone(success);
     });
+
+    //console.log('argv === ', argv);
+    //
+    //var cli = self.Cucumber.Cli(argv);
+    //
+    //cli.run(function (succeeded) {
+    //    Object.keys(originalEnv).forEach(function(envName) {
+    //      if (typeof originalEnv[envName] === 'undefined') {
+    //        delete process.env[envName];
+    //      }
+    //      else {
+    //        process.env[envName] = originalEnv[envName];
+    //      }
+    //    });
+    //
+    //  Debug('Task Done YEE: ', succeeded);
+    //
+    //    self._taskDone(succeeded);
+    //});
 
   };
 
@@ -213,25 +261,25 @@ var Main = function() {
   self._taskDone = function(success) {
     Debug('Success:', success);
 
-    //var report = self.output.join('');
-    //
-    //console.log('report:::::=== ', report);
-    //
-    //try {
-    //  report = JSON.parse(report);
-    //}
-    //catch (e) {
-    //  if (!(e instanceof SyntaxError)) {
-    //    throw e;
-    //  }
-    //
-    //  process.send({ cmd: 'error', workerIndex: self.workerIndex, profileName: self.task.profileName, message: 'Syntax error in the JSON report: ' + e });
-    //  Debug('Sent "error" message');
-    //  return;
-    //}
-    //
-    //process.send({ cmd: 'report', workerIndex: self.workerIndex, task: self.task, report: report, success: success });
-    //Debug('Sent "report" message');
+    var report = self.output.join('');
+
+    console.log('report:::::=== ', report);
+
+    try {
+      report = JSON.parse(report);
+    }
+    catch (e) {
+      if (!(e instanceof SyntaxError)) {
+        throw e;
+      }
+
+      process.send({ cmd: 'error', workerIndex: self.workerIndex, profileName: self.task.profileName, message: 'Syntax error in the JSON report: ' + e });
+      Debug('Sent "error" message');
+      return;
+    }
+
+    process.send({ cmd: 'report', workerIndex: self.workerIndex, task: self.task, report: report, success: success });
+    Debug('Sent "report" message');
     process.send({ cmd: 'next', workerIndex: self.workerIndex });
     Debug('Sent "next" message');
   };

--- a/package.json
+++ b/package.json
@@ -8,14 +8,18 @@
     "parallel",
     "scale"
   ],
-  "version": "0.1.7",
+  "version": "1.0.0",
   "homepage": "http://github.com/simondean/parallel-cucumber-js",
   "author": { 
     "name" : "Simon Dean",
     "email" : "simon@simondean.org",
     "url" : "http://www.simondean.org"
   },
-  "contributors": [],
+  "contributors": [{
+    "name": "Kushang Gajjar",
+    "email": "g.kushang@gmail.com",
+    "url": "https://github.com/gkushang"
+  }],
   "repository": {
     "type": "git",
     "url": "git://github.com/simondean/parallel-cucumber-js.git"


### PR DESCRIPTION
`parallel-cucumber-js` module does not support cucumber version greater than v0.7.0 due change in Cucumber Configurations, AST Tree Walker and CLI:

Resolves issue: https://github.com/simondean/parallel-cucumber-js/issues/16

* Adding support for Parallel executions
* Supported versions 1.x.x.
