### PR TITLE
updating to integrate with cucumber.js 0.9.x

### DIFF
--- a/features/support/world.js
+++ b/features/support/world.js
@@ -1,11 +1,7 @@
 module.exports = function() {
-  this.World = function(callback) {
-    var world = {};
-
-    world.isDryRun = function() {
+  this.World = function() {
+    this.isDryRun = function() {
       return process.argv.indexOf('--dry-run') !== -1 || process.env.PARALLEL_CUCUMBER_DRY_RUN === 'true';
     };
-
-    callback(world);
   };
-} ;
+};

--- a/lib/parallel_cucumber_worker/cli/main.js
+++ b/lib/parallel_cucumber_worker/cli/main.js
@@ -39,10 +39,9 @@ var Main = function() {
     self.Cucumber = require(cucumberPath);
     var RealAstTreeWalker = self.Cucumber.Runtime.AstTreeWalker;
 
-    self.Cucumber.Runtime.AstTreeWalker = function(features, supportCodeLibrary, listeners) {
-      var self2 = RealAstTreeWalker(features, supportCodeLibrary, listeners);
+    self.Cucumber.Runtime.AstTreeWalker = function(features, supportCodeLibrary, listeners, options) {
+      var self2 = RealAstTreeWalker(features, supportCodeLibrary, listeners, options);
 
-      var emptyCollection = self.Cucumber.Type.Collection();
       var realBroadcastEvent = self2.broadcastEvent;
       var realGetListeners = supportCodeLibrary.getListeners;
 
@@ -65,7 +64,7 @@ var Main = function() {
 
       function disableSupportCodeListeners() {
         supportCodeLibrary.getListeners = function() {
-          return emptyCollection;
+          return [];
         };
       }
 
@@ -106,19 +105,33 @@ var Main = function() {
     self.output = [];
     Debug('Task:', self.task);
 
-    // Cucumber ignores the first two arguments
-    var argv = ['', ''];
-
+    // Set cucumber defaults
+    var opts = {
+      require: [],
+      tags: [],
+      formats: ['pretty'],
+      compiler: [],
+      profile: [],
+      name: [],
+    };
+    var featurePaths = [];
     self.task.supportCodePaths.forEach(function(supportCodePath) {
-      argv.push('-r');
-      argv.push(supportCodePath);
+      opts.require.push(supportCodePath);
     });
+    
     self.task.tags.forEach(function(tagExpression) {
-      argv.push('-t');
-      argv.push(tagExpression);
+      opts.tags.push(tagExpression);
     });
-    argv.push(self.task.featureFilePath);
-    Debug('Cucumber argv:', argv);
+
+    if (self.task.formats) {
+      self.task.formats.forEach(function(formatExpression) {
+        opts.formats.push(formatExpression);
+      });
+    }
+
+    featurePaths.push(self.task.featureFilePath);
+    Debug('Cucumber options:', opts);
+    Debug('Cucumber feature paths:', featurePaths);
 
     Debug('Setting the PARALLEL_CUCUMBER_PROFILE environment variable to \'' + self.task.profileName + '\'');
     process.env.PARALLEL_CUCUMBER_PROFILE = self.task.profileName;
@@ -131,7 +144,7 @@ var Main = function() {
       process.env[envName] = self.task.env[envName];
     });
 
-    var configuration = self.Cucumber.Cli.Configuration(argv);
+    var configuration = self.Cucumber.Cli.Configuration(opts, featurePaths);
     var runtime = self.Cucumber.Runtime(configuration);
     var formatter = self.Cucumber.Listener.JsonFormatter(
       {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "version": "0.1.7",
   "homepage": "http://github.com/simondean/parallel-cucumber-js",
-  "author": { 
+  "author": {
     "name" : "Simon Dean",
     "email" : "simon@simondean.org",
     "url" : "http://www.simondean.org"
@@ -39,7 +39,7 @@
     "colors": "~0.6.2"
   },
   "peerDependencies": {
-    "cucumber": ">=0.3.1"
+    "cucumber": ">=0.9.0"
   },
   "devDependencies": {
     "grunt-cli": "~0.1.13",

--- a/test_assets/features/step_definitions/passing.js
+++ b/test_assets/features/step_definitions/passing.js
@@ -11,19 +11,6 @@ module.exports = function() {
     callback();
   });
 
-  this.When(/^an action is executed that passes on retry '(.*)'$/, function(retryCount, callback) {
-    if (this.isDryRun()) { return callback(); }
-
-    var currentRetryCount = parseInt(process.env.PARALLEL_CUCUMBER_RETRY);
-
-    if (currentRetryCount < retryCount) {
-      callback('Failed on retry ' + currentRetryCount);
-    }
-    else {
-      callback();
-    }
-  });
-
   this.Then(/^a post-condition passes$/, function(callback) {
     if (this.isDryRun()) { return callback(); }
 

--- a/test_assets/features/support/world.js
+++ b/test_assets/features/support/world.js
@@ -1,11 +1,7 @@
 module.exports = function() {
-  this.World = function(callback) {
-    var world = {};
-
-    world.isDryRun = function() {
+  this.World = function() {
+    this.isDryRun = function() {
       return process.argv.indexOf('--dry-run') !== -1 || process.env.PARALLEL_CUCUMBER_DRY_RUN === 'true';
     };
-
-    callback(world);
   };
 };


### PR DESCRIPTION
cucumber.js 0.9 brought in some breaking changes.

This PR should bring parallel-cucumber-js up to date with cucumber.js and resolve issue #16 

changes:
- duplicate step definitions will cause an ambiguity error:
https://github.com/cucumber/cucumber-js/commit/0e284313c2c75aebd53f74ea966e8c14d8946800

- AstTreeWalker now takes an options parameter: 
https://github.com/cucumber/cucumber-js/commit/d8b0ae7fb476ed3d2009ad2cf93264d7a1b6b940

- Cli.Configuration now takes an options object and an array of feature paths:
https://github.com/cucumber/cucumber-js/commit/c37d1ce98d43c43635d9898a90d9b72fe95189a4

- World function doesn't take a callback:
https://github.com/cucumber/cucumber-js/commit/50c5eb6311edfd1a8cb1ddabff77d3cc20c65f99

- listeners is now an Array:
https://github.com/cucumber/cucumber-js/commit/022e790ec27ffef117df6722e9b4a80260a3826d