### PR TITLE
Added compiler option

### DIFF
--- a/History.md
+++ b/History.md
@@ -4,6 +4,11 @@
 
 ### [master (unreleased)](https://github.com/simondean/parallel-cucumber-js/compare/v1.0.1...master)
 
+### [v1.0.2](https://github.com/simondean/parallel-cucumber-js/compare/v1.0.1...v1.0.2)
+
+#### New features
+* Added the --compiler command line argument enabling pre-processing sources (e.g. babel-register)
+
 ### [v1.0.1](https://github.com/simondean/parallel-cucumber-js/compare/v1.0.0...v1.0.1)
 
 #### Fixes

--- a/features/compiler.feature
+++ b/features/compiler.feature
@@ -1,0 +1,12 @@
+Feature: Compiler
+
+Scenario: Compiler
+    Given the 'passing' feature
+    And a 'json' formatter
+    And 'js:babel-register' compiler is set
+    When executing the parallel-cucumber-js bin
+    Then the exit code should be '0'
+    And stderr should contain text:
+    """
+    Cannot find module 'babel-register'
+    """

--- a/features/step_definitions/bin.js
+++ b/features/step_definitions/bin.js
@@ -135,6 +135,17 @@ module.exports = function() {
     callback();
   });
 
+  this.Given(/^'(.*)' compiler is set/, function(compiler, callback) {
+    if (this.isDryRun()) { return callback(); }
+    var world = this;
+
+    if (!world.compiler) {
+      world.compiler = compiler;
+    }
+
+    callback();
+  });
+
   this.Given(/^dry run mode$/, function(callback) {
     if (this.isDryRun()) { return callback(); }
 
@@ -236,6 +247,11 @@ module.exports = function() {
         args.push('-r');
         args.push(supportCodePath);
       });
+    }
+
+    if (world.compiler) {
+      args.push('--compiler');
+      args.push(world.compiler);
     }
 
     if (world.workerCount) {

--- a/lib/parallel_cucumber/cli/configuration.js
+++ b/lib/parallel_cucumber/cli/configuration.js
@@ -59,6 +59,9 @@ var Configuration = function(argv) {
     })
     .options('debug-brk', {
       describe: 'Starts cucumber workers in debug mode and breaks on the first line.  Accepts an optional port number like --debug'
+    })
+    .options('compiler', {
+      describe: 'The compiler to process sources before loading steps'
     });
   var args = self.yargs.parse(argv.slice(2));
 
@@ -73,6 +76,7 @@ var Configuration = function(argv) {
   self.dryRun = args['dry-run'];
   self.debug = args['debug'];
   self.debugBrk = args['debug-brk'];
+  self.compiler = args['compiler'];
   // Clone the array using slice()
   self.featurePaths = args._.slice();
 
@@ -95,7 +99,7 @@ var Configuration = function(argv) {
   }
 
   delete self.tags;
-  
+
   Debug('Profiles:', self.profiles);
 
   Object.keys(self.profiles).forEach(function(profileName) {
@@ -108,7 +112,7 @@ var Configuration = function(argv) {
   if (self.featurePaths.length === 0) {
     self.featurePaths.push('./features/');
   }
-  
+
   Debug('Configuration:', self);
 
   self.showHelp = function() {

--- a/lib/parallel_cucumber/runtime.js
+++ b/lib/parallel_cucumber/runtime.js
@@ -250,7 +250,8 @@ var Runtime = function (configuration) {
               supportCodePaths: options.supportCodePaths,
               tags: tags,
               env: env,
-              retryCount: 0
+              retryCount: 0,
+              compiler: options.compiler
             };
             tasks.push(task);
           }

--- a/lib/parallel_cucumber_worker/cli/main.js
+++ b/lib/parallel_cucumber_worker/cli/main.js
@@ -130,6 +130,10 @@ var Main = function() {
       });
     }
 
+    if (self.task.compiler) {
+      opts.compiler.push(self.task.compiler);
+    }
+
     featurePaths.push(self.task.featureFilePath);
     Debug('Cucumber options:', opts);
     Debug('Cucumber feature paths:', featurePaths);

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "parallel",
     "scale"
   ],
-  "version": "1.0.1",
+  "version": "1.0.2",
   "homepage": "http://github.com/simondean/parallel-cucumber-js",
   "author": {
     "name" : "Simon Dean",


### PR DESCRIPTION
The option enables parsing ES2015 step definitions (using "js:babel-register").

The test is a bit weird but we certainly don't want to add another dependency just for that.