### PR TITLE
Keep features together

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,17 @@ You can configure multiple formats, with each format configured to output to the
 $ node_modules/.bin/parallel-cucumber-js -f json:./output.json -f progress
 ```
 
+### Keeping Feature Files Together
+
+By default, scenarios will be split up and given to workers without consideration for what feature file they belong to.
+You can change this behaviour, to split up tasks as complete feature files, rather than individual scenarios by passing the `--keep-features-together` argument.
+
+This can be useful if you have designed your cucumber tests to be run as individual features, where the scenarios in a feature file depend on earlier scenarios in the same feature file having run on the same process already.
+
+``` shell
+$ node_modules/.bin/parallel-cucumber-js --keep-features-toghether
+```
+
 ### Example
 
 See https://github.com/simondean/parallel-cucumber-js-example for an example

--- a/lib/parallel_cucumber/cli/configuration.js
+++ b/lib/parallel_cucumber/cli/configuration.js
@@ -40,6 +40,11 @@ var Configuration = function(argv) {
     .options('profiles.profile_name.env.env_name', {
       describe: 'An environment variable to set when executing Cucumber scenarios for a profile.  Replace profile_name in the arg with the name of the profile.  Replace env_name with the name of the environment variable'
     })
+    
+    .options('keep-features-together', {
+      describe: 'Passes entire feature files to a worker, rather than individual scenarios. This is useful if your feature files are written with dependencies between scenarios.'
+    })
+    
     .options('cucumber', {
       describe: 'Use a custom version of cucumber-js.  Specifies either a relative path or the name of a module',
       default: 'cucumber'
@@ -68,6 +73,7 @@ var Configuration = function(argv) {
   self.supportCodePaths = ensureValueIsAnArray(args['require']);
   self.tags = ensureValueIsAnArray(args['tags']);
   self.profiles = args['profiles'];
+  self.keepFeaturesTogether = args['keep-features-together'];
   self.cucumberPath = args['cucumber'];
   self.maxRetries = args['max-retries'];
   self.dryRun = args['dry-run'];

--- a/lib/parallel_cucumber/runtime.js
+++ b/lib/parallel_cucumber/runtime.js
@@ -258,7 +258,25 @@ var Runtime = function (configuration) {
       });
     });
 
-    callback(null, tasks);
+    if (options.keepFeaturesTogether) {
+        var tasksAsWholeFeatures = [];
+        var featuresSeen = [];
+        tasks.forEach(function (task) {
+            var featureFile = task.featureFilePath.split(":")[0];
+            if (featuresSeen.indexOf(featureFile) > -1) {
+                return;
+            }
+
+            featuresSeen.push(featureFile);
+            task.featureFilePath = featureFile;
+            tasksAsWholeFeatures.push(task);        
+        })
+        
+        callback(null, tasksAsWholeFeatures);
+    } else {
+        callback(null, tasks);
+    }
+        
   };
 
   self._getFeatureFileObjects = function (featureFilePath) {


### PR DESCRIPTION
 - Create a new argument `--keep-features-together`.

 - This will pass entire feature files to a worker, rather than individual scenarios.

 - Update README.md to document new argument.

This is useful if your feature files are written with dependencies between scenarios.